### PR TITLE
#27 [Fix] UnivScheduleInfo Entity fk 삭제

### DIFF
--- a/src/main/java/umc/SukBakJi/domain/model/entity/UnivScheduleInfo.java
+++ b/src/main/java/umc/SukBakJi/domain/model/entity/UnivScheduleInfo.java
@@ -28,7 +28,6 @@ public class UnivScheduleInfo extends BaseEntity {
     @Column(nullable = false)
     private String method; // 모집전형
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "universityId")
-    private University university;
+    @Column(nullable = false)
+    private Long universityId; // fk 지정 시, 데이터 입력 불가능
 }

--- a/src/main/java/umc/SukBakJi/domain/repository/UnivScheduleInfoRepository.java
+++ b/src/main/java/umc/SukBakJi/domain/repository/UnivScheduleInfoRepository.java
@@ -7,6 +7,6 @@ import umc.SukBakJi.domain.model.entity.UnivScheduleInfo;
 import java.util.List;
 
 public interface UnivScheduleInfoRepository extends JpaRepository<UnivScheduleInfo, Long> {
-    @Query("SELECT DISTINCT u.method FROM UnivScheduleInfo u WHERE u.university.id = :univId")
+    @Query("SELECT DISTINCT u.method FROM UnivScheduleInfo u WHERE u.universityId = :univId")
     List<String> findAllByUniversityId(Long univId);
 }


### PR DESCRIPTION
## Summary
- univScheduleInfo (대학교 일정 저장) 엔티티에서 fk로 지정했던 univId를 fk에서 제외
  - fk로 지정 시, 임의로 데이터 입력이 불가능하여 삭제가 불가피함