### PR TITLE
[feat] 연구실 정보 및 후기 문의 등록 API 구현

### DIFF
--- a/src/main/java/umc/SukBakJi/domain/controller/LabController.java
+++ b/src/main/java/umc/SukBakJi/domain/controller/LabController.java
@@ -99,4 +99,15 @@ public class LabController {
         labService.cancelFavoriteLab(memberId, request);
         return ApiResponse.onSuccess("연구실을 즐겨찾기에서 삭제하였습니다.");
     }
+
+    @PostMapping("/{labId}/inquiries")
+    @Operation(summary = "연구실 정보 문의 등록",
+            description = "연구실에 잘못 기입되어 있는 정보에 대한 문의를 등록합니다.")
+    public ApiResponse<String> inquiryLabInfo(@RequestHeader("Authorization") String token,
+                                            @RequestBody LabRequestDTO.InquireLabDTO request) {
+        String jwtToken = token.substring(7);
+        Long memberId = jwtTokenProvider.getMemberIdFromToken(jwtToken);
+        labService.labUpdateRequest(memberId, request);
+        return ApiResponse.onSuccess("연구실 정보에 대한 문의를 등록하였습니다.");
+    }
 }

--- a/src/main/java/umc/SukBakJi/domain/controller/LabReviewController.java
+++ b/src/main/java/umc/SukBakJi/domain/controller/LabReviewController.java
@@ -7,11 +7,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
-import umc.SukBakJi.domain.model.dto.LabReviewSearchDTO;
-import umc.SukBakJi.domain.model.dto.LabReviewSummaryDTO;
+import umc.SukBakJi.domain.model.dto.*;
 import umc.SukBakJi.global.apiPayload.ApiResponse;
-import umc.SukBakJi.domain.model.dto.LabReviewCreateDTO;
-import umc.SukBakJi.domain.model.dto.LabReviewDetailsDTO;
 import umc.SukBakJi.domain.service.LabReviewService;
 import umc.SukBakJi.global.apiPayload.code.ErrorReasonDTO;
 import umc.SukBakJi.global.security.jwt.JwtTokenProvider;
@@ -125,5 +122,16 @@ public class LabReviewController {
     ) {
         List<LabReviewDetailsDTO> reviewList = labReviewService.searchLabReviews(searchDTO.getProfessorName());
         return ApiResponse.onSuccess(reviewList);
+    }
+
+    @PostMapping("/{labId}/inquiries")
+    @Operation(summary = "연구실 후기 문의 등록",
+            description = "연구실 후기에 잘못 기입되어 있는 정보에 대한 문의를 등록합니다.")
+    public ApiResponse<String> inquiryLabInfo(@RequestHeader("Authorization") String token,
+                                         @RequestBody LabRequestDTO.InquireLabReviewDTO request) {
+        String jwtToken = token.substring(7);
+        Long memberId = jwtTokenProvider.getMemberIdFromToken(jwtToken);
+        labReviewService.labReviewUpdateRequest(memberId, request);
+        return ApiResponse.onSuccess("연구실 후기에 대한 문의를 등록하였습니다.");
     }
 }

--- a/src/main/java/umc/SukBakJi/domain/converter/AuthConverter.java
+++ b/src/main/java/umc/SukBakJi/domain/converter/AuthConverter.java
@@ -8,7 +8,7 @@ import umc.SukBakJi.domain.model.entity.Member;
 public class AuthConverter {
     public static MemberResponseDto.LoginResponseDto toLoginDto(Provider provider, Member member, JwtToken jwtToken) {
         return MemberResponseDto.LoginResponseDto.builder()
-                .provider(provider.getValue())
+                .provider(provider)
                 .email(member.getEmail())
                 .accessToken(jwtToken.getAccessToken())
                 .refreshToken(jwtToken.getRefreshToken())

--- a/src/main/java/umc/SukBakJi/domain/converter/MemberConverter.java
+++ b/src/main/java/umc/SukBakJi/domain/converter/MemberConverter.java
@@ -25,7 +25,6 @@ public class MemberConverter {
                 .name(member.getName())
                 .degreeLevel(member.getDegreeLevel())
                 .researchTopics(resarchTopics)
-                .point(member.getPoint())
                 .build();
     }
 
@@ -34,7 +33,6 @@ public class MemberConverter {
                 .name(member.getName())
                 .degreeLevel(member.getDegreeLevel())
                 .researchTopics(resarchTopics)
-                .point(member.getPoint())
                 .build();
     }
 }

--- a/src/main/java/umc/SukBakJi/domain/model/dto/LabRequestDTO.java
+++ b/src/main/java/umc/SukBakJi/domain/model/dto/LabRequestDTO.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import umc.SukBakJi.domain.model.entity.enums.RequestCategory;
 
 import java.util.List;
 
@@ -14,5 +15,24 @@ public class LabRequestDTO {
     @AllArgsConstructor
     public static class CancelLabDTO {
         private List<Long> labIds;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class InquireLabDTO {
+        private Long labId;
+        private RequestCategory requestCategory;
+        private String content;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class InquireLabReviewDTO {
+        private Long labReviewId;
+        private String content;
     }
 }

--- a/src/main/java/umc/SukBakJi/domain/model/dto/auth/OAuth2RequestDTO.java
+++ b/src/main/java/umc/SukBakJi/domain/model/dto/auth/OAuth2RequestDTO.java
@@ -4,12 +4,13 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import umc.SukBakJi.domain.model.entity.enums.Provider;
 
 @Builder
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public class OAuth2RequestDTO {
-    private String provider;
+    private Provider provider;
     private String accessToken;
 }

--- a/src/main/java/umc/SukBakJi/domain/model/dto/member/MemberResponseDto.java
+++ b/src/main/java/umc/SukBakJi/domain/model/dto/member/MemberResponseDto.java
@@ -28,6 +28,5 @@ public class MemberResponseDto {
         private Provider provider;
         private DegreeLevel degreeLevel;
         private List<String> researchTopics;
-        private Integer point;
     }
 }

--- a/src/main/java/umc/SukBakJi/domain/model/dto/member/MemberResponseDto.java
+++ b/src/main/java/umc/SukBakJi/domain/model/dto/member/MemberResponseDto.java
@@ -13,7 +13,7 @@ public class MemberResponseDto {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class LoginResponseDto {
-        private String provider;
+        private Provider provider;
         private String email;
         private String accessToken;
         private String refreshToken;

--- a/src/main/java/umc/SukBakJi/domain/model/entity/Member.java
+++ b/src/main/java/umc/SukBakJi/domain/model/entity/Member.java
@@ -37,9 +37,6 @@ public class Member extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private DegreeLevel degreeLevel;
 
-    @ColumnDefault("0")
-    private Integer point;
-
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Provider provider;
@@ -80,13 +77,12 @@ public class Member extends BaseEntity {
     @OneToMany(mappedBy = "member")
     private List<Scrap> scraps;
 
-    public Member(String name, String password, String email, String phoneNumber, DegreeLevel degreeLevel, int point, Provider provider) {
+    public Member(String name, String password, String email, String phoneNumber, DegreeLevel degreeLevel, Provider provider) {
         this.name = name;
         this.password = password;
         this.email = email;
         this.phoneNumber = phoneNumber;
         this.degreeLevel = degreeLevel;
-        this.point = point;
         this.provider = provider;
     }
 
@@ -100,11 +96,6 @@ public class Member extends BaseEntity {
 
     public void resetRefreshToken() {
         this.refreshToken = null;
-    }
-
-    @PrePersist
-    public void setPoint() {
-        this.point = 0;
     }
 
     public Long getMemberId() {

--- a/src/main/java/umc/SukBakJi/domain/model/entity/enums/LabUpdateStatus.java
+++ b/src/main/java/umc/SukBakJi/domain/model/entity/enums/LabUpdateStatus.java
@@ -1,0 +1,17 @@
+package umc.SukBakJi.domain.model.entity.enums;
+
+public enum LabUpdateStatus {
+    PENDING("대기 중"),
+    APPROVED("승인됨"),
+    REJECTED("반려됨");
+
+    private final String value;
+
+    LabUpdateStatus(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/src/main/java/umc/SukBakJi/domain/model/entity/enums/RequestCategory.java
+++ b/src/main/java/umc/SukBakJi/domain/model/entity/enums/RequestCategory.java
@@ -1,0 +1,17 @@
+package umc.SukBakJi.domain.model.entity.enums;
+
+public enum RequestCategory {
+    PROFESSOR_INFO("교수 정보"),
+    LAB_INFO("연구실 정보"),
+    RESEARCH_TOPIC("연구 주제");
+
+    private final String value;
+
+    RequestCategory(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/src/main/java/umc/SukBakJi/domain/model/entity/mapping/LabReviewUpdateRequest.java
+++ b/src/main/java/umc/SukBakJi/domain/model/entity/mapping/LabReviewUpdateRequest.java
@@ -16,6 +16,7 @@ public class LabReviewUpdateRequest {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false)
     private String content;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/umc/SukBakJi/domain/model/entity/mapping/LabReviewUpdateRequest.java
+++ b/src/main/java/umc/SukBakJi/domain/model/entity/mapping/LabReviewUpdateRequest.java
@@ -1,0 +1,31 @@
+package umc.SukBakJi.domain.model.entity.mapping;
+
+import jakarta.persistence.*;
+import lombok.*;
+import umc.SukBakJi.domain.model.entity.Member;
+import umc.SukBakJi.domain.model.entity.enums.LabUpdateStatus;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "lab_review_update_request")
+public class LabReviewUpdateRequest {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    private LabUpdateStatus labUpdateStatus;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "review_id")
+    private LabReview labReview;
+}

--- a/src/main/java/umc/SukBakJi/domain/model/entity/mapping/LabUpdateRequest.java
+++ b/src/main/java/umc/SukBakJi/domain/model/entity/mapping/LabUpdateRequest.java
@@ -19,8 +19,10 @@ public class LabUpdateRequest {
     private Long id;
 
     @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
     private RequestCategory requestCategory;
 
+    @Column(nullable = false)
     private String content;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/umc/SukBakJi/domain/model/entity/mapping/LabUpdateRequest.java
+++ b/src/main/java/umc/SukBakJi/domain/model/entity/mapping/LabUpdateRequest.java
@@ -1,0 +1,36 @@
+package umc.SukBakJi.domain.model.entity.mapping;
+
+import jakarta.persistence.*;
+import lombok.*;
+import umc.SukBakJi.domain.model.entity.Lab;
+import umc.SukBakJi.domain.model.entity.Member;
+import umc.SukBakJi.domain.model.entity.enums.LabUpdateStatus;
+import umc.SukBakJi.domain.model.entity.enums.RequestCategory;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "lab_update_request")
+public class LabUpdateRequest {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private RequestCategory requestCategory;
+
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    private LabUpdateStatus labUpdateStatus;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "lab_id")
+    private Lab lab;
+}

--- a/src/main/java/umc/SukBakJi/domain/repository/LabReviewUpdateRequestRepository.java
+++ b/src/main/java/umc/SukBakJi/domain/repository/LabReviewUpdateRequestRepository.java
@@ -1,0 +1,7 @@
+package umc.SukBakJi.domain.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.SukBakJi.domain.model.entity.mapping.LabReviewUpdateRequest;
+
+public interface LabReviewUpdateRequestRepository extends JpaRepository<LabReviewUpdateRequest, Long> {
+}

--- a/src/main/java/umc/SukBakJi/domain/repository/LabUpdateRequestRepository.java
+++ b/src/main/java/umc/SukBakJi/domain/repository/LabUpdateRequestRepository.java
@@ -1,0 +1,7 @@
+package umc.SukBakJi.domain.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.SukBakJi.domain.model.entity.mapping.LabUpdateRequest;
+
+public interface LabUpdateRequestRepository extends JpaRepository<LabUpdateRequest, Long> {
+}

--- a/src/main/java/umc/SukBakJi/domain/service/AuthService.java
+++ b/src/main/java/umc/SukBakJi/domain/service/AuthService.java
@@ -114,10 +114,8 @@ public class AuthService {
         member.resetRefreshToken();
     }
 
-    public MemberResponseDto.LoginResponseDto oauthLogin(String provider, String accessToken) {
-        Provider oauthProvider = Provider.valueOf(provider.toUpperCase());
-
-        return switch (oauthProvider) {
+    public MemberResponseDto.LoginResponseDto oauthLogin(Provider provider, String accessToken) {
+        return switch (provider) {
             case KAKAO -> kakaoService.kakaoLogin(accessToken);
 //            case APPLE -> appleService.appleLogin(accessToken);
             default -> throw new IllegalArgumentException("지원하지 않는 로그인 방식: " + provider);

--- a/src/main/java/umc/SukBakJi/domain/service/LabReviewService.java
+++ b/src/main/java/umc/SukBakJi/domain/service/LabReviewService.java
@@ -125,6 +125,10 @@ public class LabReviewService {
         LabReview labReview = labReviewRepository.findById(request.getLabReviewId())
                 .orElseThrow(() -> new LabHandler(ErrorStatus.LAB_REVIEW_NOT_FOUND));
 
+        if (request.getContent() == null || request.getContent().trim().isEmpty()) {
+            throw new LabHandler(ErrorStatus.INVALID_INQUIRY_CONTENT);
+        }
+
         labReviewUpdateRequestRepository.save(
                 LabReviewUpdateRequest.builder()
                         .member(member)

--- a/src/main/java/umc/SukBakJi/domain/service/LabReviewService.java
+++ b/src/main/java/umc/SukBakJi/domain/service/LabReviewService.java
@@ -1,5 +1,6 @@
 package umc.SukBakJi.domain.service;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -10,32 +11,36 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import umc.SukBakJi.domain.converter.LabReviewConverter;
-import umc.SukBakJi.domain.model.dto.LabReviewSummaryDTO;
-import umc.SukBakJi.domain.model.dto.TriangleGraphData;
+import umc.SukBakJi.domain.model.dto.*;
+import umc.SukBakJi.domain.model.entity.Member;
+import umc.SukBakJi.domain.model.entity.enums.LabUpdateStatus;
+import umc.SukBakJi.domain.model.entity.mapping.LabReviewUpdateRequest;
+import umc.SukBakJi.domain.model.entity.mapping.LabUpdateRequest;
+import umc.SukBakJi.domain.repository.LabReviewUpdateRequestRepository;
+import umc.SukBakJi.domain.repository.MemberRepository;
 import umc.SukBakJi.global.apiPayload.code.status.ErrorStatus;
 import umc.SukBakJi.global.apiPayload.exception.GeneralException;
-import umc.SukBakJi.domain.model.dto.LabReviewCreateDTO;
-import umc.SukBakJi.domain.model.dto.LabReviewDetailsDTO;
 import umc.SukBakJi.domain.model.entity.Lab;
 import umc.SukBakJi.domain.model.entity.mapping.LabReview;
 import umc.SukBakJi.domain.repository.LabRepository;
 import umc.SukBakJi.domain.repository.LabReviewRepository;
+import umc.SukBakJi.global.apiPayload.exception.handler.LabHandler;
+import umc.SukBakJi.global.apiPayload.exception.handler.MemberHandler;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
+@RequiredArgsConstructor
 public class LabReviewService {
 
-    @Autowired
-    private LabReviewRepository labReviewRepository;
+    private final LabReviewUpdateRequestRepository labReviewUpdateRequestRepository;
+    private final MemberRepository memberRepository;
+    private final LabReviewRepository labReviewRepository;
+    private final LabRepository labRepository;
 
-    @Autowired
-    private LabRepository labRepository;
-
-    @Autowired
-    private LabReviewConverter labReviewConverter;
+    private final LabReviewConverter labReviewConverter;
 
     public LabReviewSummaryDTO getLabReviews(Long labId) {
         List<LabReview> reviews = labReviewRepository.findByLabId(labId);
@@ -110,5 +115,23 @@ public class LabReviewService {
         }
 
         return labReviewConverter.toDto(reviews);
+    }
+
+    // 연구실 후기 문의 등록
+    public void labReviewUpdateRequest(Long memberId, LabRequestDTO.InquireLabReviewDTO request) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+
+        LabReview labReview = labReviewRepository.findById(request.getLabReviewId())
+                .orElseThrow(() -> new LabHandler(ErrorStatus.LAB_REVIEW_NOT_FOUND));
+
+        labReviewUpdateRequestRepository.save(
+                LabReviewUpdateRequest.builder()
+                        .member(member)
+                        .labReview(labReview)
+                        .content(request.getContent())
+                        .labUpdateStatus(LabUpdateStatus.PENDING)
+                        .build()
+        );
     }
 }

--- a/src/main/java/umc/SukBakJi/domain/service/LabService.java
+++ b/src/main/java/umc/SukBakJi/domain/service/LabService.java
@@ -163,6 +163,10 @@ public class LabService {
         Lab lab = labRepository.findById(request.getLabId())
                 .orElseThrow(() -> new LabHandler(ErrorStatus.LAB_NOT_FOUND));
 
+        if (request.getContent() == null || request.getContent().trim().isEmpty()) {
+            throw new LabHandler(ErrorStatus.INVALID_INQUIRY_CONTENT);
+        }
+
         labUpdateRequestRepository.save(
                 LabUpdateRequest.builder()
                         .member(member)

--- a/src/main/java/umc/SukBakJi/domain/service/LabService.java
+++ b/src/main/java/umc/SukBakJi/domain/service/LabService.java
@@ -7,17 +7,21 @@ import umc.SukBakJi.domain.converter.LabConverter;
 import umc.SukBakJi.domain.model.dto.LabRequestDTO;
 import umc.SukBakJi.domain.model.entity.Lab;
 import umc.SukBakJi.domain.model.entity.Member;
+import umc.SukBakJi.domain.model.entity.enums.LabUpdateStatus;
 import umc.SukBakJi.domain.model.entity.mapping.FavoriteLab;
 import umc.SukBakJi.domain.model.entity.mapping.LabResearchTopic;
+import umc.SukBakJi.domain.model.entity.mapping.LabUpdateRequest;
 import umc.SukBakJi.domain.repository.FavoriteLabRepository;
 import umc.SukBakJi.domain.model.dto.InterestTopicsDTO;
 import umc.SukBakJi.domain.model.dto.LabDetailResponseDTO;
 import umc.SukBakJi.domain.model.dto.LabResponseDTO;
 import umc.SukBakJi.domain.model.entity.ResearchTopic;
 import umc.SukBakJi.domain.repository.LabRepository;
+import umc.SukBakJi.domain.repository.LabUpdateRequestRepository;
 import umc.SukBakJi.domain.repository.MemberRepository;
 import umc.SukBakJi.global.apiPayload.code.status.ErrorStatus;
 import umc.SukBakJi.global.apiPayload.exception.GeneralException;
+import umc.SukBakJi.global.apiPayload.exception.handler.LabHandler;
 import umc.SukBakJi.global.apiPayload.exception.handler.MemberHandler;
 
 import java.util.*;
@@ -31,6 +35,7 @@ public class LabService {
     private final MemberRepository memberRepository;
     private final LabRepository labRepository;
     private final FavoriteLabRepository favoriteLabRepository;
+    private final LabUpdateRequestRepository labUpdateRequestRepository;
 
     public List<LabResponseDTO> searchLabsByTopicName(String topicName) {
         List<Lab> labs = labRepository.findLabsByResearchTopicName(topicName);
@@ -148,5 +153,24 @@ public class LabService {
             throw new GeneralException(ErrorStatus.FAVORITE_NOT_FOUND);
         }
         favoriteLabRepository.deleteAll(favoriteLabs);
+    }
+
+    // 연구실 문의 등록
+    public void labUpdateRequest(Long memberId, LabRequestDTO.InquireLabDTO request) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+
+        Lab lab = labRepository.findById(request.getLabId())
+                .orElseThrow(() -> new LabHandler(ErrorStatus.LAB_NOT_FOUND));
+
+        labUpdateRequestRepository.save(
+                LabUpdateRequest.builder()
+                        .member(member)
+                        .lab(lab)
+                        .requestCategory(request.getRequestCategory())
+                        .content(request.getContent())
+                        .labUpdateStatus(LabUpdateStatus.PENDING)
+                        .build()
+        );
     }
 }

--- a/src/main/java/umc/SukBakJi/domain/service/MemberService.java
+++ b/src/main/java/umc/SukBakJi/domain/service/MemberService.java
@@ -68,7 +68,6 @@ public class MemberService {
         member.setName(profileDto.getName());
         member.setDegreeLevel(profileDto.getDegreeLevel());
         member.setMemberResearchTopics(memberResearchTopics);
-        member.setPoint(1000); // 회원가입 시 프로필 설정까지 진행되면 1000 포인트 부여
         memberRepository.save(member);
 
         return MemberConverter.toSetMemberProfile(member, profileDto.getResearchTopics());
@@ -160,7 +159,6 @@ public class MemberService {
                 .provider(member.getProvider())
                 .degreeLevel(member.getDegreeLevel())
                 .researchTopics(memberResearchTopics)
-                .point(member.getPoint())
                 .build();
     }
 

--- a/src/main/java/umc/SukBakJi/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/SukBakJi/global/apiPayload/code/status/ErrorStatus.java
@@ -66,6 +66,9 @@ public enum ErrorStatus implements BaseErrorCode {
     INVALID_PROFESSOR_NAME(HttpStatus.NOT_FOUND, "PROFESSOR4042", "지도교수 이름을 찾을 수 없습니다."),
     SCRAP_NOT_FOUND(HttpStatus.NOT_FOUND, "SCRAP4001", "스크랩 목록에서 찾을 수 없습니다."),
 
+    // 문의 관련 에러
+    INVALID_INQUIRY_CONTENT(HttpStatus.BAD_REQUEST, "REQUEST4001", "문의 내용이 유효하지 않습니다."),
+
     // 게시판 관련 오류
     BOARD_NOT_FOUND(HttpStatus.NOT_FOUND, "BOARD4041", "게시판을 찾을 수 없습니다."),
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST4041", "게시글을 찾을 수 없습니다."),

--- a/src/main/java/umc/SukBakJi/global/apiPayload/exception/handler/LabHandler.java
+++ b/src/main/java/umc/SukBakJi/global/apiPayload/exception/handler/LabHandler.java
@@ -1,0 +1,10 @@
+package umc.SukBakJi.global.apiPayload.exception.handler;
+
+import umc.SukBakJi.global.apiPayload.code.BaseErrorCode;
+import umc.SukBakJi.global.apiPayload.exception.GeneralException;
+
+public class LabHandler extends GeneralException {
+    public LabHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}


### PR DESCRIPTION
- `POST` /api/labs/{labId}/inquiries : 연구실 정보 문의 등록
- `POST` /api/labs/reivews/{labReviewId}/inquries : 연구실 후기 문의 등록

상세 내용
- 각 API에 맞는 비즈니스 로직 구현
- 에러 테스트 및 확인

+ 추가로 포인트 관련 기능 삭제